### PR TITLE
Exceptions from CancellationToken callbacks are hard to catch, don't.

### DIFF
--- a/Snowflake.Data.Tests/SFBaseTest.cs
+++ b/Snowflake.Data.Tests/SFBaseTest.cs
@@ -76,15 +76,9 @@ namespace Snowflake.Data.Tests
         [OneTimeSetUp]
         public void SFTestSetup()
         {
-#if NET46
-            log4net.GlobalContext.Properties["framework"] = "net46";
-            log4net.Config.XmlConfigurator.Configure();
-
-#else
             log4net.GlobalContext.Properties["framework"] = "netcoreapp2.0";
             var logRepository = log4net.LogManager.GetRepository(Assembly.GetEntryAssembly());
             log4net.Config.XmlConfigurator.Configure(logRepository, new FileInfo("App.config"));
-#endif
             String cloud = Environment.GetEnvironmentVariable("snowflake_cloud_env");
             Assert.IsTrue(cloud == null || cloud == "AWS" || cloud == "AZURE" || cloud == "GCP", "{0} is not supported. Specify AWS, AZURE or GCP as cloud environment", cloud);
 

--- a/Snowflake.Data.Tests/Snowflake.Data.Tests.csproj
+++ b/Snowflake.Data.Tests/Snowflake.Data.Tests.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp2.0;net46</TargetFrameworks>
+    <TargetFrameworks>netcoreapp2.0</TargetFrameworks>
     <Title>Snowflake.Data.Tests</Title>
     <Description>Snowflake Connector for .NET</Description>
     <Company>Snowflake Computing, Inc</Company>
@@ -24,18 +24,9 @@
     <Folder Include="Properties\" />
   </ItemGroup>
   
-  <ItemGroup Condition="'$(TargetFramework)' == 'net46'">
-    <Reference Include="System.Net.Http" />
-    <Reference Include="System.Web" />
-  </ItemGroup>
   
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
     <DebugType>full</DebugType>
     <DebugSymbols>True</DebugSymbols>
   </PropertyGroup>
-  <!--<ItemGroup Condition="'$(TargetFramework)' == 'net46'">
-    <Reference Include="System.Net.Http" />
-    <Reference Include="System.Web" />
-    <Reference Include="Snowflake.Data" />
-  </ItemGroup> -->
 </Project>

--- a/Snowflake.Data/Snowflake.Data.csproj
+++ b/Snowflake.Data/Snowflake.Data.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;net46</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0</TargetFrameworks>
     <Title>Seismic.Snowflake.Data</Title>
     <PackageId>Seismic.Snowflake.Data</PackageId>
     <PackageLicenseUrl>https://github.com/snowflakedb/snowflake-connector-net/blob/master/LICENSE</PackageLicenseUrl>
@@ -22,12 +22,6 @@
     <PackageReference Include="log4net" Version="2.0.8" />
   </ItemGroup>
   
-  <ItemGroup Condition="'$(TargetFramework)' == 'net46'">
-    <Reference Include="System.Net.Http" />
-    <Reference Include="System.Web" />
-    <Reference Include="System.Configuration" />
-  </ItemGroup>
-
   <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
     <PackageReference Include="System.Configuration.ConfigurationManager" Version="4.5.0" />
   </ItemGroup>

--- a/Snowflake.Data/Snowflake.Data.csproj
+++ b/Snowflake.Data/Snowflake.Data.csproj
@@ -1,8 +1,8 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>netstandard2.0;net46</TargetFrameworks>
-    <Title>Snowflake.Data</Title>
-    <PackageId>Snowflake.Data</PackageId>
+    <Title>Seismic.Snowflake.Data</Title>
+    <PackageId>Seismic.Snowflake.Data</PackageId>
     <PackageLicenseUrl>https://github.com/snowflakedb/snowflake-connector-net/blob/master/LICENSE</PackageLicenseUrl>
     <PackageProjectUrl>https://github.com/snowflakedb/snowflake-connector-net</PackageProjectUrl>
     <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>
@@ -12,7 +12,7 @@
     <Product>Snowflake Connector for .NET</Product>
     <Authors>howryu, tchen</Authors>
     <Copyright>Copyright (c) 2012-2019 Snowflake Computing Inc. All rights reserved.</Copyright>
-    <Version>1.1.2</Version>
+    <Version>1.1.2.1</Version>
     <DebugType>Full</DebugType>
   </PropertyGroup>
 	


### PR DESCRIPTION
I like this guy's perspective on raising Exceptions from CancellationToken callbacks: Don't.

Blog: https://bengribaudo.com/blog/2018/02/08/4360/understanding-cancellation-callbacks
TL;DR Stack overflow version: https://stackoverflow.com/a/48712879/1169710

So this change makes it so failed cancellations in background threads are hinted not to throw their exceptions, and swallow them instead. Not perfect, but should work well enough for our purposes.

Other changes are to change the package name to limit confusion and to not build for Framework4.6 because I don't think we care. I don't anyway.